### PR TITLE
Save to and load from .yaml files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]

--- a/src/fio.jl
+++ b/src/fio.jl
@@ -89,8 +89,34 @@ function save_json(fname::AbstractString, D::Dict; indent=0)
     return nothing
 end
 
-load_dict = load_json
-save_dict = save_json
+function load_yaml(fname::AbstractString)
+   return YAML.load_file(fname)
+end
+
+function save_yaml(fname::AbstractString, D::Dict)
+   YAML.write_file(fname, D) 
+   return nothing
+end
+
+function load_dict(fname::AbstractString)
+   if endswith(fname, ".json")
+      return load_json(fname)
+   elseif endswith(fname, ".yaml") || enswith(fname, ".yml")
+      return load_yaml(fname)
+   else
+      throw(error("Unrecognised file format. Expected: \"*.json\" or \"*.yaml\", got filename: $(fname)"))
+   end
+end
+
+function save_dict(fname::AbstractString, D::Dict; indent=0)
+   if endswith(fname, ".json")
+      return save_json(fname, D; indent=indent)
+   elseif endswith(fname, ".yaml") || enswith(fname, ".yml")
+      return save_yaml(fname, D)
+   else
+      throw(error("Unrecognised file format. Expected: \"*.json\" or \"*.yaml\", got filename: $(fname)"))
+   end
+end
 
 
 function zip_dict(fname::AbstractString, D::Dict; indent=0)

--- a/src/fio.jl
+++ b/src/fio.jl
@@ -10,13 +10,14 @@ can be changed later. This submodule provides
 """
 module FIO
 
-using JSON, ZipFile
+using JSON, YAML, ZipFile
 using SparseArrays: SparseMatrixCSC
 
 export read_dict, write_dict,
        zip_dict, unzip_dict,
        load_json, save_json,
-       load_dict, save_dict 
+       load_dict, save_dict,
+       load_yaml, save_yaml
 
 
 #######################################################################


### PR DESCRIPTION
Extend `load_dict` and `save_dict` to work with `*.yaml` files. The format is picked based on the filename suffix. 