### PR TITLE
Cleanup global variable workaround for ZipFile.jl bug and test `zip_dict`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,15 +12,15 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
-ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
+ZipArchives = "49080126-0e18-4c2a-b176-c102e4b3760c"
 
 [compat]
-julia = "1.8"
 JSON = "0.21"
 Reexport = "1"
 StaticArrays = "1"
 YAML = "0.4"
-ZipFile = "0.9, 0.10"
+ZipArchives = "2"
+julia = "1.8"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test_fio.jl
+++ b/test/test_fio.jl
@@ -25,4 +25,14 @@ for O in objects
    println_slim(@test all(test_fio(O)))
 end
 
+# Test zip_dict and unzip_dict work
+for O in objects
+   tmpf = tempname()
+   D = write_dict(O)
+   save_json(tmpf * ".json", D)
+   Djson = load_json(tmpf * ".json")
+   zip_dict(tmpf * ".zip", D)
+   Dzip = unzip_dict(tmpf * ".zip")
+   println_slim(@test Dzip == Djson)
+end
 


### PR DESCRIPTION
This PR switches from ZipFile.jl to [ZipArchives.jl](https://github.com/JuliaIO/ZipArchives.jl) so the weird global variable workaround for https://github.com/fhs/ZipFile.jl/issues/14 can be removed.