### PR TITLE
Add natural_indices to the shared evaluation interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ACEbase"
 uuid = "14bae519-eb20-449c-a949-9c58ed33163e"
 authors = ["Christoph Ortner <christophortner0@gmail.com> and contributors"]
-version = "0.4.6"
+version = "0.4.7"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/src/ACEbase.jl
+++ b/src/ACEbase.jl
@@ -24,6 +24,11 @@ function pullback! end
 function pushforward! end 
 function pushforward end 
 
+# shared "spec" accessor: returns a vector of natural descriptions of the
+# basis functions, in the order they are stored in the output of `evaluate`.
+# As with the evaluate interface, the concrete format is not restricted here.
+function natural_indices end
+
 # these could be useful functions to share across ACEsuit packages as well since 
 # there are many different ways how one can allocate and release memory. 
 # For now, we will make them owned by ObjectPools.jl so that that package 


### PR DESCRIPTION
Adds a `natural_indices` function stub alongside the existing `evaluate*`
stubs, so it can serve as a shared ACEsuit interface function (returning a
basis's "natural" descriptions, e.g. `(l, m)` for spherical harmonics, in
storage order).

This is the enabling change for decoupling SpheriCart from Polynomials4ML:
- SpheriCart's new `ACEbaseExt` defines `natural_indices` for its harmonics
  (lab-cosmo/sphericart#235).
- Polynomials4ML switches its `natural_indices` to
  `import ACEbase: natural_indices` (ACEsuit/Polynomials4ML.jl#123).

No behaviour change for existing code; patch bump 0.4.6 → 0.4.7.
Should be registered first, as #235 and #123 require it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)